### PR TITLE
Fix subscribe compilation warnings

### DIFF
--- a/modules/subscribe/subscribe.c
+++ b/modules/subscribe/subscribe.c
@@ -1,5 +1,6 @@
 #include <re.h>
 #include <baresip.h>
+#include <stdlib.h>
 
 struct subscription {
     struct le le;
@@ -18,6 +19,8 @@ static void sub_destructor(void *arg)
 
 static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 {
+    (void)event;
+    (void)arg;
     if (ev == UA_EVENT_SHUTDOWN) {
         struct le *le;
         for (le = subl.head; le; le = le->next) {
@@ -90,8 +93,8 @@ static void notify_handler(struct sip *sip, const struct sip_msg *msg,
     if (!sub || !ua)
         return;
 
-	// Trigger NOTIFY event
-	notify_event_emit(ua, msg);
+    // Trigger NOTIFY event
+    notify_event_emit(ua, msg);
 }
 
 static int auth_handler(char **username, char **password,
@@ -103,12 +106,15 @@ static int auth_handler(char **username, char **password,
 static void close_handler(int err, const struct sip_msg *msg,
                           const struct sipevent_substate *substate, void *arg)
 {
+    (void)err;
+    (void)msg;
+    (void)substate;
     struct subscription *sub = arg;
     list_unlink(&sub->le);
     mem_deref(sub);
 }
 
-static void cmd_subscribe(struct re_printf *pf, void *arg)
+static int cmd_subscribe(struct re_printf *pf, void *arg)
 {
 	const struct cmd_arg *carg = arg;
     struct le *le = NULL;
@@ -123,14 +129,14 @@ static void cmd_subscribe(struct re_printf *pf, void *arg)
 
     if (!ua) {
         re_hprintf(pf, "No registered UA available\n");
-        return;
+        return 0;
     }
 
     const char *line = (const char *)carg->prm;
 
     if (!line || *line == '\0') {
         re_hprintf(pf, "Usage: /subscribe <target> <event> <expires>\n");
-        return;
+        return 0;
     }
 
     // Duplicate line so strtok doesn't modify const memory
@@ -145,14 +151,14 @@ static void cmd_subscribe(struct re_printf *pf, void *arg)
 
     if (!target || !event || !expires_str) {
         re_hprintf(pf, "Usage: /subscribe <target> <event> <expires>\n");
-        return;
+        return 0;
     }
     uint32_t expires = (uint32_t)strtoul(expires_str, NULL, 10);
 
     struct subscription *sub = mem_zalloc(sizeof(*sub), sub_destructor);
     if (!sub) {
         re_hprintf(pf, "Memory allocation error\n");
-        return;
+        return 0;
     }
 
     sub->ua = mem_ref(ua);
@@ -168,8 +174,8 @@ static void cmd_subscribe(struct re_printf *pf, void *arg)
         if (!hdr) continue;
         pos += snprintf(hdrstr + pos, sizeof(hdrstr) - pos,
                         "%.*s: %.*s\r\n",
-                        hdr->name.l, hdr->name.p,
-                        hdr->val.l, hdr->val.p);
+                        (int)hdr->name.l, hdr->name.p,
+                        (int)hdr->val.l, hdr->val.p);
     }
     hdrstr[pos] = '\0';  // ensure null-terminated
 
@@ -190,14 +196,14 @@ static void cmd_subscribe(struct re_printf *pf, void *arg)
 
     if (err) {
         re_hprintf(pf, "Subscribe failed: %m\n", err);
-        return;
+        return 0;
     }
 	/* TODO: Send SUBSCRIBE event*/
     re_hprintf(pf, "Subscription sent to %s for event %s\n", target, event);
 
     list_append(&subl, &sub->le, sub);
 
-    return;
+    return 0;
 }
 
 static const struct cmd cmdv[] = {


### PR DESCRIPTION
Fixed couple of issues popping up during compilation:

```
[ 76%] Building C object modules/subscribe/CMakeFiles/subscribe.dir/subscribe.c.o
/src/modules/subscribe/subscribe.c: In function 'event_handler':
/src/modules/subscribe/subscribe.c:19:60: warning: unused parameter 'event' [-Wunused-parameter]
   19 | static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
      |                                             ~~~~~~~~~~~~~~~^~~~~
/src/modules/subscribe/subscribe.c:19:73: warning: unused parameter 'arg' [-Wunused-parameter]
   19 | static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
      |                                                                   ~~~~~~^~~
/src/modules/subscribe/subscribe.c: In function 'notify_handler':
/src/modules/subscribe/subscribe.c:90:5: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
   90 |     if (!sub || !ua)
      |     ^~
/src/modules/subscribe/subscribe.c:94:9: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
   94 |         notify_event_emit(ua, msg);
      |         ^~~~~~~~~~~~~~~~~
/src/modules/subscribe/subscribe.c: In function 'close_handler':
/src/modules/subscribe/subscribe.c:103:31: warning: unused parameter 'err' [-Wunused-parameter]
  103 | static void close_handler(int err, const struct sip_msg *msg,
      |                           ~~~~^~~
/src/modules/subscribe/subscribe.c:103:58: warning: unused parameter 'msg' [-Wunused-parameter]
  103 | static void close_handler(int err, const struct sip_msg *msg,
      |                                    ~~~~~~~~~~~~~~~~~~~~~~^~~
/src/modules/subscribe/subscribe.c:104:59: warning: unused parameter 'substate' [-Wunused-parameter]
  104 |                           const struct sipevent_substate *substate, void *arg)
      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
/src/modules/subscribe/subscribe.c: In function 'cmd_subscribe':
/src/modules/subscribe/subscribe.c:150:34: warning: implicit declaration of function 'strtoul'; did you mean 'strtok'? [-Wimplicit-function-declaration]
  150 |     uint32_t expires = (uint32_t)strtoul(expires_str, NULL, 10);
      |                                  ^~~~~~~
      |                                  strtok
/src/modules/subscribe/subscribe.c:150:34: warning: nested extern declaration of 'strtoul' [-Wnested-externs]
/src/modules/subscribe/subscribe.c:170:28: warning: field precision specifier '.*' expects argument of type 'int', but argument 4 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  170 |                         "%.*s: %.*s\r\n",
      |                          ~~^~
      |                            |
      |                            int
  171 |                         hdr->name.l, hdr->name.p,
      |                         ~~~~~~~~~~~
      |                                  |
      |                                  size_t {aka long unsigned int}
/src/modules/subscribe/subscribe.c:170:34: warning: field precision specifier '.*' expects argument of type 'int', but argument 6 has type 'size_t' {aka 'long unsigned int'} [-Wformat=]
  170 |                         "%.*s: %.*s\r\n",
      |                                ~~^~
      |                                  |
      |                                  int
  171 |                         hdr->name.l, hdr->name.p,
  172 |                         hdr->val.l, hdr->val.p);
      |                         ~~~~~~~~~~
      |                                 |
      |                                 size_t {aka long unsigned int}
/src/modules/subscribe/subscribe.c: At top level:
/src/modules/subscribe/subscribe.c:204:53: warning: initialization of 'int (*)(struct re_printf *, void *)' from incompatible pointer type 'void (*)(struct re_printf *, void *)' [-Wincompatible-pointer-types]
  204 |     { "subscribe", 0, CMD_PRM, "Send subscription", cmd_subscribe }
      |                                                     ^~~~~~~~~~~~~
/src/modules/subscribe/subscribe.c:204:53: note: (near initialization for 'cmdv[0].h')
```