### PR TITLE
Fix OpenAI uplink capture on ECS via decode-path aufilt tap.

### DIFF
--- a/modules/openai_rt/README.md
+++ b/modules/openai_rt/README.md
@@ -26,9 +26,11 @@ The reader thread continuously captures audio data from the SIP call. Since audi
 
 ### SIP to OpenAI
 
-Audio is read in the audio.c `ausrc_read_thread()` in a loop, then:
+Uplink PCM is tapped on the **RTP decode thread** via an `aufilt` decode handler (after `auresamp`, before `aubuf`). This avoids relying on a detached `auplay` poll thread that can chronically underrun `aubuf` under container scheduling.
 
-1. The reader thread captures audio from the SIP call via the ausrc interface.
+The `auplay` thread only drains `aubuf` so the RX buffer does not overflow; it does not feed OpenAI.
+
+1. Each decoded RTP frame passes through the `openai_rt` decode filter at 24 kHz.
 2. Audio data (PCM16 24kHz mono) is encoded to base64.
 3. A JSON message with type `input_audio_buffer.append` is created containing the base64 audio.
 4. The message is queued to the websocket thread via the `to_openai_queue`.
@@ -69,9 +71,11 @@ Also ensure the `auresamp` module is loaded to handle sample rate conversion:
 
 ```
 module_path         /path/to/modules
-module              auresamp.so
 module              openai_rt.so
+module              auresamp.so
 ```
+
+`openai_rt.so` must load **before** `auresamp.so` so the uplink decode filter runs after resampling.
 
 ## Session Setup
 

--- a/modules/openai_rt/audio.c
+++ b/modules/openai_rt/audio.c
@@ -30,6 +30,15 @@ static void send_audio_commit(void);
 static void force_audio_commit(void);
 static void maybe_shrink_injection_buffer(void);
 
+/* Decode-path uplink tap (runs on RTP thread after auresamp) */
+struct uplink_filt_dec {
+	struct aufilt_dec_st af;
+};
+
+static struct aufilt uplink_filt;
+static bool uplink_filt_registered;
+static bool uplink_filt_warned_srate;
+
 /* Audio source structure - provides audio to baresip */
 struct ausrc_st {
     struct ausrc_prm prm;
@@ -127,6 +136,15 @@ int audio_init(void)
     g_audio.injection_read_pos = 0;
     g_audio.injection_write_pos = 0;
     g_audio.injection_available = 0;
+
+    g_audio.uplink_batch_cap = UPLINK_BATCH_BYTES / sizeof(int16_t);
+    g_audio.uplink_batch_len = 0;
+    g_audio.uplink_batch = mem_alloc(g_audio.uplink_batch_cap * sizeof(int16_t),
+                                     NULL);
+    if (!g_audio.uplink_batch) {
+        warning("openai_rt: Failed to allocate uplink batch buffer\n");
+        goto cleanup;
+    }
     
     /* Initialize injection buffer mutex */
     int err = mtx_init(&g_audio.injection_buffer_mutex, mtx_plain);
@@ -194,6 +212,7 @@ cleanup:
     mem_deref(g_audio.g711u_input_buffer);
     mem_deref(g_audio.g711u_output_buffer);
     mem_deref(g_audio.injection_buffer);
+    mem_deref(g_audio.uplink_batch);
     /* Note: src_st and play_st are not allocated during init, so no need to free them here */
     return ENOMEM;
 }
@@ -201,6 +220,11 @@ cleanup:
 /* Clean up audio subsystem */
 void audio_close(void)
 {
+    if (uplink_filt_registered) {
+        aufilt_unregister(&uplink_filt);
+        uplink_filt_registered = false;
+    }
+
     /* Always clean up, regardless of whether audio threads were active */
     
     /* Stop audio threads if they exist */
@@ -233,6 +257,9 @@ void audio_close(void)
     
     /* Free injection buffer */
     g_audio.injection_buffer = mem_deref(g_audio.injection_buffer);
+    g_audio.uplink_batch = mem_deref(g_audio.uplink_batch);
+    g_audio.uplink_batch_len = 0;
+    g_audio.uplink_batch_cap = 0;
     
     /* Free audio structures - only if they were allocated */
     if (g_audio.src_st) {
@@ -245,38 +272,27 @@ void audio_close(void)
     DEBUG_INFO("Audio subsystem closed\n");
 }
 
-void handle_incoming_audio(const int16_t *s16_data, size_t sampc)
+static void queue_pcm_append(const int16_t *s16_data, size_t sampc)
 {
     struct ai_model *model = get_ai_model();
     char *json_msg = NULL;
     int err;
+    size_t byte_len;
 
-    if (!s16_data || sampc == 0) {
-        DEBUG_INFO("handle_incoming_audio: No audio data or zero samples\n");
+    if (!s16_data || sampc == 0)
         return;
-    }
-    
-    if (!g_oairt.call_active) {
-        DEBUG_INFO("handle_incoming_audio: Call not active, dropping audio\n");
-        return;
-    }
-    
+
     if (!model || !model->build_audio_append) {
         warning("openai_rt: AI model not initialized\n");
         return;
     }
 
-    size_t byte_len = sampc * sizeof(int16_t);
-    //info("[AUDIO TX] Received %zu samples (%zu bytes) from pipeline\n", sampc, byte_len);
-    
+    byte_len = sampc * sizeof(int16_t);
     char *b64 = encode_audio_base64((const uint8_t *)s16_data, byte_len);
     if (!b64) {
         warning("openai_rt: base64 encode failed for %zu bytes\n", byte_len);
         return;
     }
-
-    //size_t b64_len = str_len(b64);
-    //info("[AUDIO TX] Base64 encoded %zu bytes to %zu chars\n", byte_len, b64_len);
 
     err = model->build_audio_append(b64, &json_msg);
     mem_deref(b64);
@@ -286,28 +302,139 @@ void handle_incoming_audio(const int16_t *s16_data, size_t sampc)
         return;
     }
 
-    if (json_msg) {
-        size_t msg_len = str_len(json_msg);
-        //info("[AUDIO TX] Built audio message (%zu bytes), queuing to WebSocket (ws_state=%d, ws_client=%p)\n",
-        //           msg_len, g_oairt.ws_state, g_oairt.ws_client);
-        
-        err = queue_message_to_openai(json_msg, msg_len, NULL, NULL);
-        if (err) {
-            warning("openai_rt: Failed to queue PCM audio: %m\n", err);
-        } else {
-            //info("[AUDIO TX] Audio message queued successfully (total queued: %zu bytes)\n", g_audio.audio_accumulated + byte_len);
-            g_audio.audio_accumulated += byte_len;
-            if (g_audio.audio_accumulated >= g_audio.commit_threshold) {
-                if (g_oairt.session_cfg_applied) {
-                    //info("[AUDIO TX] Threshold reached, sending commit\n");
-                    send_audio_commit();
-                } else {
-                    DEBUG_INFO("Skipping commit - session not ready yet\n");
-                }
-                g_audio.audio_accumulated = 0;
-            }
+    if (!json_msg)
+        return;
+
+    err = queue_message_to_openai(json_msg, str_len(json_msg), NULL, NULL);
+    if (err) {
+        warning("openai_rt: Failed to queue PCM audio: %m\n", err);
+    } else {
+        g_audio.audio_accumulated += byte_len;
+        if (g_audio.audio_accumulated >= g_audio.commit_threshold) {
+            if (g_oairt.session_cfg_applied)
+                send_audio_commit();
+            else
+                DEBUG_INFO("Skipping commit - session not ready yet\n");
+            g_audio.audio_accumulated = 0;
         }
-        mem_deref(json_msg);
+    }
+    mem_deref(json_msg);
+}
+
+static void flush_uplink_batch_internal(bool force)
+{
+    if (!g_audio.uplink_batch || g_audio.uplink_batch_len == 0)
+        return;
+
+    if (!force &&
+        g_audio.uplink_batch_len * sizeof(int16_t) < UPLINK_BATCH_BYTES)
+        return;
+
+    queue_pcm_append(g_audio.uplink_batch, g_audio.uplink_batch_len);
+    g_audio.uplink_batch_len = 0;
+}
+
+static void uplink_filt_dec_destructor(void *arg)
+{
+	struct uplink_filt_dec *st = arg;
+
+	list_unlink(&st->af.le);
+}
+
+static int uplink_filt_dec_update(struct aufilt_dec_st **stp, void **ctx,
+				  const struct aufilt *af, struct aufilt_prm *prm,
+				  const struct audio *au)
+{
+	struct uplink_filt_dec *st;
+
+	(void)ctx;
+	(void)af;
+	(void)prm;
+	(void)au;
+
+	if (!stp)
+		return EINVAL;
+
+	if (*stp)
+		return 0;
+
+	st = mem_zalloc(sizeof(*st), uplink_filt_dec_destructor);
+	if (!st)
+		return ENOMEM;
+
+	*stp = (struct aufilt_dec_st *)st;
+	uplink_filt_warned_srate = false;
+	info("openai_rt: uplink decode filter active (rtp-thread capture)\n");
+
+	return 0;
+}
+
+static int uplink_filt_decode(struct aufilt_dec_st *st, struct auframe *af)
+{
+	(void)st;
+
+	if (!g_oairt.call_active || !af || af->sampc == 0)
+		return 0;
+
+	if (af->fmt != AUFMT_S16LE)
+		return 0;
+
+	if (af->srate != 24000 && !uplink_filt_warned_srate) {
+		warning("openai_rt: uplink tap srate=%u (expected 24000); "
+			"load openai_rt.so before auresamp.so in config\n",
+			af->srate);
+		uplink_filt_warned_srate = true;
+	}
+
+	openai_rt_receive_audio(af->sampv, af->sampc);
+
+	return 0;
+}
+
+void audio_register_uplink_filter(void)
+{
+	uplink_filt.name    = "openai_rt_uplink";
+	uplink_filt.encupdh = NULL;
+	uplink_filt.ench    = NULL;
+	uplink_filt.decupdh = uplink_filt_dec_update;
+	uplink_filt.dech    = uplink_filt_decode;
+
+	aufilt_register(baresip_aufiltl(), &uplink_filt);
+	uplink_filt_registered = true;
+}
+
+void audio_flush_uplink_batch(void)
+{
+    flush_uplink_batch_internal(true);
+}
+
+void handle_incoming_audio(const int16_t *s16_data, size_t sampc)
+{
+    size_t copy;
+    size_t space;
+
+    if (!s16_data || sampc == 0)
+        return;
+
+    if (!g_oairt.call_active)
+        return;
+
+    if (!g_audio.uplink_batch)
+        return;
+
+    while (sampc > 0) {
+        if (g_audio.uplink_batch_len >= g_audio.uplink_batch_cap)
+            flush_uplink_batch_internal(true);
+
+        space = g_audio.uplink_batch_cap - g_audio.uplink_batch_len;
+        copy = sampc < space ? sampc : space;
+        memcpy(g_audio.uplink_batch + g_audio.uplink_batch_len,
+               s16_data, copy * sizeof(int16_t));
+        g_audio.uplink_batch_len += copy;
+        s16_data += copy;
+        sampc -= copy;
+
+        flush_uplink_batch_internal(false);
     }
 }
 
@@ -486,7 +613,13 @@ static int ausrc_read_thread(void *arg)
         }
 
         if (have < st->sampc) {
-            memset(st->sampv + have, 0, (st->sampc - have) * sizeof(int16_t));
+            static int16_t last_sample;
+            size_t i;
+
+            if (have > 0)
+                last_sample = st->sampv[have - 1];
+            for (i = have; i < st->sampc; i++)
+                st->sampv[i] = last_sample;
         } else if (have > st->sampc) {
             have = st->sampc;
         }
@@ -514,7 +647,12 @@ static int ausrc_read_thread(void *arg)
     return 0;
 }
 
-/* Audio playback write thread - continuously calls st->wh() to get audio from baresip */
+/*
+ * Drain aubuf via baresip's auplay handler so the RX buffer does not grow
+ * without bound.  Uplink to OpenAI is captured on the RTP decode thread by
+ * the openai_rt aufilt (after auresamp), not here — a separate poll thread
+ * racing aubuf caused sustained underruns (all-zero uplink) on ECS.
+ */
 static int auplay_write_thread(void *arg)
 {
     struct auplay_st *st = arg;
@@ -523,40 +661,27 @@ static int auplay_write_thread(void *arg)
         return 0;
     }
     
-    DEBUG_INFO("Audio playback thread started\n");
+    DEBUG_INFO("Audio playback drain thread started\n");
     
-    /* Create a single auframe ONCE at the beginning (like WASAPI/ALSA) */
     struct auframe af;
     auframe_init(&af, st->prm.fmt, st->sampv, st->sampc,
                st->prm.srate, st->prm.ch);
     
     while (st->run && st->ready) {
-        /* Check if call is still active - stop if not */
         if (!g_oairt.call_active) {
-            DEBUG_INFO("Audio playback thread stopping - call ended\n");
+            DEBUG_INFO("Audio playback drain thread stopping - call ended\n");
             break;
         }
         
-        /* Wait for audio data from the SIP call */
-        /* This is the key: we need to wait for actual audio, not return immediately */
         if (st->wh) {
-            /* Call baresip's write handler - this should provide audio data */
             st->wh(&af, st->arg);
             st->total_samples_received += af.sampc;
-            
-            /* Process the audio data from the populated frame */
-            if (af.sampc > 0) {
-                openai_rt_receive_audio(af.sampv, af.sampc);
-            }
-        } else {
-            DEBUG_INFO("No write handler available\n");
         }
         
-        /* Sleep to maintain proper timing - this prevents the 1ms loop */
         sys_msleep(st->prm.ptime);
     }
     
-    DEBUG_INFO("Audio playback thread ended\n");
+    DEBUG_INFO("Audio playback drain thread ended\n");
     return 0;
 }
 
@@ -709,7 +834,8 @@ void openai_rt_check_messages(void)
 /* Stop audio threads when call ends */
 void audio_stop_threads(void)
 {
-    
+    audio_flush_uplink_batch();
+
     /* Properly free all audio frames in queues to prevent memory leaks */
     free_audio_queue(&g_audio.read_queue, &g_audio.read_queue_mutex);
     free_event_queue(&g_audio.event_queue, &g_audio.event_queue_mutex);
@@ -893,11 +1019,11 @@ bool audio_source_ready_for_injection(void)
 /* Public function to receive audio from baresip */
 void openai_rt_receive_audio(const int16_t *sampv, size_t sampc)
 {
-    if (!g_audio.play_st || !g_audio.play_st->ready || !g_oairt.call_active) {
+    if (!g_oairt.call_active || !sampv || sampc == 0)
         return;
-    }
 
-    g_audio.play_st->total_samples_received += sampc;
+    if (g_audio.play_st)
+        g_audio.play_st->total_samples_received += sampc;
     handle_incoming_audio(sampv, sampc);
 }
 
@@ -953,6 +1079,9 @@ int audio_queue_event(enum event_type type, void *data)
     list_append(&g_audio.event_queue, &event->le, event);
     cnd_signal(&g_audio.event_queue_cond);
     mtx_unlock(&g_audio.event_queue_mutex);
+
+    if (type == EVENT_CALL_START)
+        websocket_kick_session_setup();
     
     /* If this is a call start event and audio drivers are ready, start threads */
     if (type == EVENT_CALL_START && audio_ready_for_call()) {
@@ -1100,10 +1229,13 @@ static void force_audio_commit(void)
 /* Reset audio state for new call */
 void audio_reset_for_new_call(void)
 {
-    
+    audio_flush_uplink_batch();
+
     /* Reset accumulation tracking */
     g_audio.audio_accumulated = 0;
     g_audio.response_created = false;
+    if (g_audio.uplink_batch)
+        g_audio.uplink_batch_len = 0;
     
     /* Reset injection buffer state */
     mtx_lock(&g_audio.injection_buffer_mutex);
@@ -1126,6 +1258,8 @@ void audio_reset_for_new_call(void)
 /* Flush accumulated audio when session becomes ready */
 void audio_flush_accumulated(void)
 {
+    audio_flush_uplink_batch();
+
     if (g_audio.audio_accumulated > 0) {
         double ms = (double)g_audio.audio_accumulated / 2 / 24000.0 * 1000.0;
         info("openai_rt: flushing %.1f ms (%u bytes) of accumulated audio\n",

--- a/modules/openai_rt/calls.c
+++ b/modules/openai_rt/calls.c
@@ -175,38 +175,24 @@ static void event_handler(enum ua_event ev, struct bevent *event, void *arg)
 			/* Reset audio state for new call */
 			audio_reset_for_new_call();
 			
-			/* Check if session setup is ready - if not, we need to wait or hang up */
+			/* Kick session.update without blocking the UA event chain (sndfile etc.) */
 			if (!websocket_is_ready()) {
 				int qerr;
+
 				warning("openai_rt: Call established but WebSocket not ready (status=%s)\n",
 				        websocket_status_string());
 
-				/* Re-trigger call start handling to force reconnect/session.update now. */
 				qerr = audio_queue_event(EVENT_CALL_START, call);
 				if (qerr) {
 					warning("openai_rt: Failed to queue call start event (established): %m\n", qerr);
 				}
-				
-				/* Wait for WebSocket + session.updated to complete */
-				int wait_err = websocket_wait_ready(10000);
-				if (wait_err) {
-					warning("openai_rt: Session setup failed or timed out after 10 seconds (status=%s) - hanging up call\n",
-					        websocket_status_string());
-					calls_hangup();
-					break;
-				}
+				websocket_kick_session_setup();
+			}
+			else {
+				info("openai_rt: Session ready, call can proceed\n");
 			}
 			
-			/* Verify session is actually ready */
-			if (!g_oairt.session_ready || !g_oairt.session_cfg_applied) {
-				warning("openai_rt: Session setup not complete - hanging up call\n");
-				calls_hangup();
-				break;
-			}
-			
-			info("openai_rt: Session ready, call can proceed\n");
-			
-			/* Start audio threads now that call is established and session is ready */
+			/* Start audio threads; uplink commits wait for session_cfg_applied */
 			if (audio_ready_for_call()) {
 				DEBUG_INFO("Call established - starting audio threads\n");
 				audio_restart_threads();

--- a/modules/openai_rt/openai_rt.c
+++ b/modules/openai_rt/openai_rt.c
@@ -71,7 +71,8 @@ static int module_init(void)
 		goto out;
 	}
 
-    
+	audio_register_uplink_filter();
+
 	err = calls_init();
 	if (err) {
 		warning("openai_rt: failed to initialize call management: %m\n", err);

--- a/modules/openai_rt/openai_rt.h
+++ b/modules/openai_rt/openai_rt.h
@@ -110,6 +110,7 @@ bool websocket_is_ready(void);
 int websocket_wait_ready(int timeout_ms);
 const char *websocket_status_string(void);
 void send_session_update(void);
+void websocket_kick_session_setup(void);
 int queue_message_to_openai(const char *json_msg, size_t len, 
                            void (*callback)(void *arg, int err), void *arg);
 int queue_message_from_openai(const uint8_t *data, size_t len);
@@ -118,6 +119,7 @@ void websocket_clear_message_queue(void);
 /* Audio functions - Audio driver implementation */
 int audio_init(void);
 void audio_close(void);
+void audio_register_uplink_filter(void);
 void handle_incoming_audio(const int16_t *s16_data, size_t sampc);
 void handle_outgoing_audio(const uint8_t *g711u_data, size_t len);
 void openai_rt_check_messages(void);
@@ -127,6 +129,7 @@ void audio_stop_threads(void);
 void audio_restart_threads(void);
 void audio_reset_for_new_call(void);
 void audio_flush_accumulated(void);
+void audio_flush_uplink_batch(void);
 bool audio_source_ready_for_injection(void);
 bool audio_threads_running(void);
 bool audio_ready_for_call(void);
@@ -203,12 +206,23 @@ struct audio_state {
     size_t injection_write_pos;        /* Write position in circular buffer */
     size_t injection_available;        /* Number of samples available for reading */
     mtx_t injection_buffer_mutex;      /* Mutex for injection buffer access */
-    
+
+    /* Batched PCM uplink (phone -> OpenAI), flushed as one append */
+    int16_t *uplink_batch;
+    size_t uplink_batch_cap;           /* capacity in samples */
+    size_t uplink_batch_len;           /* samples currently buffered */
 };
 
 /* Audio commit threshold - commit after accumulating this many bytes */
 /* 800ms at 24kHz PCM16 = 24000 * 2 * 0.8 = 38400 bytes */
 #define AUDIO_COMMIT_THRESHOLD 38400
+
+/* PoC: batch uplink PCM before one WS append (reduces queue pressure on ECS) */
+#define UPLINK_BATCH_MS 100
+#define UPLINK_BATCH_BYTES ((24000 * UPLINK_BATCH_MS / 1000) * sizeof(int16_t))
+
+/* Skip near-silent output deltas (leading AAAA chunks from API) */
+#define OUTPUT_DELTA_PEAK_MIN 64
 
 /* Injection buffer sizing limits */
 #define INJECTION_BUFFER_INITIAL_SIZE 128000    /* Initial size in samples (16 seconds @ 8kHz) */

--- a/modules/openai_rt/websocket.c
+++ b/modules/openai_rt/websocket.c
@@ -48,79 +48,72 @@ static void handle_response_done_cb(const char *response_json, void *arg);
      mem_deref(msg->data);
  }
  
- /* Process outgoing messages */
+#define WS_DRAIN_MAX_PER_WRITABLE 32
+
+ /* Process outgoing messages (drain multiple per writable callback) */
  static void process_outgoing_messages(void)
  {
-     struct ws_message *msg = NULL;
-     struct le *le;
- 
-     pthread_mutex_lock(&g_oairt.ws_mutex);
-     le = list_head(&g_oairt.to_openai_queue);
-     if (le) {
-         msg = list_ledata(le);
-         list_unlink(le);
-     }
-     pthread_mutex_unlock(&g_oairt.ws_mutex);
- 
-     if (!msg || !g_oairt.ws_client) {
-         return;
-     }
- 
-     /* Check if we can write */
-     if (lws_send_pipe_choked(g_oairt.ws_client)) {
-         /* Put message back in queue */
-         pthread_mutex_lock(&g_oairt.ws_mutex);
-         list_prepend(&g_oairt.to_openai_queue, &msg->le, msg);
-         pthread_mutex_unlock(&g_oairt.ws_mutex);
-         return;
-     }
- 
-    /* Check if this is an audio message */
-    bool is_audio = (msg->len > 0 && 
-                     (strstr((const char *)(msg->data + LWS_PRE), "\"audio\"") != NULL ||
-                      strstr((const char *)(msg->data + LWS_PRE), "\"realtimeInput\"") != NULL ||
-                      strstr((const char *)(msg->data + LWS_PRE), "\"audioBytes\"") != NULL));
-    
-    if (is_audio) {
-        //info("[AUDIO TX] Sending audio message via WebSocket (%zu bytes)\n", msg->len);
-    } else {
-        DEBUG_INFO("process_outgoing_messages: Sending message (%zu bytes)\n", msg->len);
-    }
+     unsigned n;
 
-    /* Send the message */
-    int written = lws_write(g_oairt.ws_client, msg->data + LWS_PRE, msg->len, LWS_WRITE_TEXT);
-    if (written < 0) {
-        warning("openai_rt: Failed to write WebSocket message\n");
-        /* Put message back in queue */
-        pthread_mutex_lock(&g_oairt.ws_mutex);
-        list_prepend(&g_oairt.to_openai_queue, &msg->le, msg);
-        pthread_mutex_unlock(&g_oairt.ws_mutex);
-    } else if (written < (int)msg->len) {
-        /* Partial write, update message and put back in queue */
-        memmove(msg->data + LWS_PRE, msg->data + LWS_PRE + written, msg->len - written);
-        msg->len -= written;
-        pthread_mutex_lock(&g_oairt.ws_mutex);
-        list_prepend(&g_oairt.to_openai_queue, &msg->le, msg);
-        pthread_mutex_unlock(&g_oairt.ws_mutex);
-    } else {
-        /* Full message sent */
-        if (is_audio) {
-            //info("[AUDIO TX] Audio message sent successfully via WebSocket (%d bytes)\n", written);
-        } else {
-            DEBUG_INFO("process_outgoing_messages: Message sent successfully (%d bytes)\n", written);
-        }
-        /* Full message sent, call callback if provided */
-        if (msg->callback) {
-            msg->callback(msg->arg, 0);
-        }
-        mem_deref(msg);
-    }
- 
-     /* If there are more messages to send, request another writable callback */
-     pthread_mutex_lock(&g_oairt.ws_mutex);
-     if (!list_isempty(&g_oairt.to_openai_queue) && g_oairt.ws_client) {
-         lws_callback_on_writable(g_oairt.ws_client);
+     for (n = 0; n < WS_DRAIN_MAX_PER_WRITABLE; n++) {
+         struct ws_message *msg = NULL;
+         struct le *le;
+         bool is_audio;
+         int written;
+
+         if (!g_oairt.ws_client)
+             break;
+
+         if (lws_send_pipe_choked(g_oairt.ws_client))
+             break;
+
+         pthread_mutex_lock(&g_oairt.ws_mutex);
+         le = list_head(&g_oairt.to_openai_queue);
+         if (le) {
+             msg = list_ledata(le);
+             list_unlink(le);
+         }
+         pthread_mutex_unlock(&g_oairt.ws_mutex);
+
+         if (!msg)
+             break;
+
+         is_audio = (msg->len > 0 &&
+             (strstr((const char *)(msg->data + LWS_PRE), "\"audio\"") != NULL ||
+              strstr((const char *)(msg->data + LWS_PRE), "\"realtimeInput\"") != NULL ||
+              strstr((const char *)(msg->data + LWS_PRE), "\"audioBytes\"") != NULL));
+
+         written = lws_write(g_oairt.ws_client, msg->data + LWS_PRE,
+                             msg->len, LWS_WRITE_TEXT);
+         if (written < 0) {
+             warning("openai_rt: Failed to write WebSocket message\n");
+             pthread_mutex_lock(&g_oairt.ws_mutex);
+             list_prepend(&g_oairt.to_openai_queue, &msg->le, msg);
+             pthread_mutex_unlock(&g_oairt.ws_mutex);
+             break;
+         }
+
+         if (written < (int)msg->len) {
+             warning("openai_rt: partial WS write (%d/%zu), requeueing message\n",
+                     written, msg->len);
+             pthread_mutex_lock(&g_oairt.ws_mutex);
+             list_prepend(&g_oairt.to_openai_queue, &msg->le, msg);
+             pthread_mutex_unlock(&g_oairt.ws_mutex);
+             break;
+         }
+
+         if (!is_audio)
+             DEBUG_INFO("process_outgoing_messages: Message sent (%zu bytes)\n",
+                        msg->len);
+
+         if (msg->callback)
+             msg->callback(msg->arg, 0);
+         mem_deref(msg);
      }
+
+     pthread_mutex_lock(&g_oairt.ws_mutex);
+     if (!list_isempty(&g_oairt.to_openai_queue) && g_oairt.ws_client)
+         lws_callback_on_writable(g_oairt.ws_client);
      pthread_mutex_unlock(&g_oairt.ws_mutex);
  }
  
@@ -205,11 +198,18 @@ static void handle_audio_delta(const char *base64_audio, void *arg)
     if (decoded && nbytes >= 2) {
         const int16_t *pcm = (const int16_t *)decoded;
         size_t nsamp = nbytes / 2;
-        
-        /* Determine backend rate for logging */
-        //uint32_t backend_rate = (g_oairt.backend_type == AI_BACKEND_GEMINI_LIVE) ? 16000 : 24000;
-        //info("[AUDIO RX] Decoded %zu base64 chars to %zu samples (%zu bytes) at %u Hz\n",
-        //     b64_len, nsamp, nbytes, backend_rate);
+        int16_t peak = 0;
+        size_t i;
+
+        for (i = 0; i < nsamp; i++) {
+            int16_t a = pcm[i] < 0 ? (int16_t)-pcm[i] : pcm[i];
+            if (a > peak)
+                peak = a;
+        }
+        if (peak < OUTPUT_DELTA_PEAK_MIN) {
+            mem_deref(decoded);
+            return;
+        }
         
         int err = write_to_injection_buffer(pcm, nsamp);
         if (err) {
@@ -238,8 +238,14 @@ static void handle_speech_started_cb(void *arg)
 {
     (void)arg;
 
+    /* Caller waits for remote greeting: do not wipe outbound buffer on their speech */
+    if (g_oairt.wait_for_greeting) {
+        DEBUG_INFO("openai_rt: speech.started (wait_for_greeting), "
+                   "keeping injection buffer\n");
+        return;
+    }
+
     DEBUG_INFO("openai_rt: speech.started received, interrupt ongoing audio output\n");
-    /* clear the injection buffer */
     mtx_lock(&g_audio.injection_buffer_mutex);
     g_audio.injection_read_pos = 0;
     g_audio.injection_write_pos = 0;
@@ -700,6 +706,17 @@ static void handle_response_done_cb(const char *response_json, void *arg)
      }
  }
  
+void websocket_kick_session_setup(void)
+{
+	if (g_oairt.ws_state == WS_CONNECTED && !g_oairt.session_ready)
+		send_session_update();
+
+	ws_wake_service();
+
+	if (g_oairt.ws_state == WS_CONNECTED && g_oairt.ws_client)
+		lws_callback_on_writable(g_oairt.ws_client);
+}
+
  void send_session_update(void)
 {
     struct ai_model *model = get_ai_model();
@@ -754,11 +771,7 @@ static void handle_response_done_cb(const char *response_json, void *arg)
     pthread_mutex_lock(&g_oairt.ws_mutex);
     //DEBUG_INFO("Queueing message to OpenAI: %s\n", json_msg);
     list_append(&g_oairt.to_openai_queue, &msg->le, msg);
-    //size_t queue_size = list_count(&g_oairt.to_openai_queue);
     pthread_mutex_unlock(&g_oairt.ws_mutex);
-
-    //DEBUG_INFO("queue_message_to_openai: Message queued (len=%zu), queue size=%zu, ws_state=%d\n",
-    //           len, queue_size, g_oairt.ws_state);
 
     /* Wake the I/O thread right away */
     ws_wake_service();


### PR DESCRIPTION
Tap PCM on the RTP decode thread after auresamp instead of the auplay poll thread, batch uplink appends, and avoid blocking CALL_ESTABLISHED on WebSocket readiness so calls and recordings are not torn down early.