### PR TITLE
clear TTS buffer on barge-in and fix underrun hum

### DIFF
--- a/modules/openai_rt/audio.c
+++ b/modules/openai_rt/audio.c
@@ -615,13 +615,17 @@ static int ausrc_read_thread(void *arg)
         }
 
         if (have < st->sampc) {
-            static int16_t last_sample;
             size_t i;
 
-            if (have > 0)
-                last_sample = st->sampv[have - 1];
-            for (i = have; i < st->sampc; i++)
-                st->sampv[i] = last_sample;
+            if (have == 0) {
+                memset(st->sampv, 0, st->sampc * sizeof(int16_t));
+            }
+            else {
+                int16_t last = st->sampv[have - 1];
+
+                for (i = have; i < st->sampc; i++)
+                    st->sampv[i] = last;
+            }
         } else if (have > st->sampc) {
             have = st->sampc;
         }
@@ -1243,12 +1247,7 @@ void audio_reset_for_new_call(void)
     if (g_audio.uplink_batch)
         g_audio.uplink_batch_len = 0;
     
-    /* Reset injection buffer state */
-    mtx_lock(&g_audio.injection_buffer_mutex);
-    g_audio.injection_read_pos = 0;
-    g_audio.injection_write_pos = 0;
-    g_audio.injection_available = 0;
-    mtx_unlock(&g_audio.injection_buffer_mutex);
+    audio_clear_injection_buffer();
     
     /* Clear any stale audio data */
     if (g_audio.g711u_input_buffer) {
@@ -1274,7 +1273,14 @@ void audio_flush_accumulated(void)
     }
 }
 
-/* audio.c */
+void audio_clear_injection_buffer(void)
+{
+    mtx_lock(&g_audio.injection_buffer_mutex);
+    g_audio.injection_read_pos = 0;
+    g_audio.injection_write_pos = 0;
+    g_audio.injection_available = 0;
+    mtx_unlock(&g_audio.injection_buffer_mutex);
+}
 
 /* Resize the injection buffer to accommodate more data */
 int resize_injection_buffer(size_t new_size_samples)

--- a/modules/openai_rt/gemini.c
+++ b/modules/openai_rt/gemini.c
@@ -654,9 +654,9 @@ static int gemini_parse_message(const char *json_str,
 		/* Check for interrupted flag - when True, clear audio buffer (similar to OpenAI speech_started) */
 		struct json_object *interrupted_obj = get_json_object_field_optional(server_content, "interrupted");
 		if (interrupted_obj && json_object_is_type(interrupted_obj, json_type_boolean)) {
-			if (json_object_get_boolean(interrupted_obj) && speech_started_cb) {
+			if (json_object_get_boolean(interrupted_obj)) {
 				DEBUG_INFO("openai_rt: Gemini serverContent.interrupted=True, clearing audio buffer\n");
-				speech_started_cb(cb_arg);
+				audio_clear_injection_buffer();
 			}
 		}
 

--- a/modules/openai_rt/openai_rt.h
+++ b/modules/openai_rt/openai_rt.h
@@ -132,6 +132,7 @@ void audio_restart_threads(void);
 void audio_reset_for_new_call(void);
 void audio_flush_accumulated(void);
 void audio_flush_uplink_batch(void);
+void audio_clear_injection_buffer(void);
 bool audio_source_ready_for_injection(void);
 bool audio_threads_running(void);
 bool audio_ready_for_call(void);

--- a/modules/openai_rt/websocket.c
+++ b/modules/openai_rt/websocket.c
@@ -250,20 +250,8 @@ static void handle_speech_started_cb(void *arg)
 {
     (void)arg;
 
-    /* Caller waits for remote greeting: do not wipe outbound buffer on their speech */
-    if (g_oairt.wait_for_greeting) {
-        DEBUG_INFO("openai_rt: speech.started (wait_for_greeting), "
-                   "keeping injection buffer\n");
-        return;
-    }
-
-    DEBUG_INFO("openai_rt: speech.started received, interrupt ongoing audio output\n");
-    mtx_lock(&g_audio.injection_buffer_mutex);
-    g_audio.injection_read_pos = 0;
-    g_audio.injection_write_pos = 0;
-    g_audio.injection_available = 0;
-    mtx_unlock(&g_audio.injection_buffer_mutex);
-    DEBUG_INFO("openai_rt: injection buffer cleared\n");
+    DEBUG_INFO("openai_rt: speech.started, interrupting outbound TTS\n");
+    audio_clear_injection_buffer();
 }
 
 static void handle_function_call_cb(const char *call_id, const char *name,


### PR DESCRIPTION
Reduce AI TTS hum and barge-in bleed by fixing injection-buffer underrun
padding and always clearing queued audio when the user interrupts.